### PR TITLE
Support a notarization-only workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ zip {
     }
 }
 ```
+Example of "notarization only"
+```hcl
+sources = []
+bundle_id = "com.mitchellh.example.terraform"
+
+notarize {
+  package = "/path/to/terraform.pkg"
+  staple = true
+}
+
+apple_id {
+  username = "mitchell@example.com"
+  password = "@env:AC_PASSWORD"
+}
+```
 
 Supported configurations:
 
@@ -189,6 +204,12 @@ Supported configurations:
   * `bundle_id` (`string`) - The [bundle ID](https://cocoacasts.com/what-are-app-ids-and-bundle-identifiers/)
     for your application. You should choose something unique for your application.
     You can also [register these with Apple](https://developer.apple.com/account/resources/identifiers/list).
+
+  * `notarize` (optional) - Settings for notarizing an already built .pkg or .zip. An alternative to using the `source` 
+
+    * `package` (`string`) - The path to the file to notarize
+
+    * `staple` (`bool`) - Controls if `stapler staple` should run if notarization succeeds
 
   * `apple_id` - Settings related to the Apple ID to use for notarization.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,8 +10,12 @@ type Config struct {
 	// be anything, this is required by Apple.
 	BundleId string `hcl:"bundle_id"`
 
+	// Notarize is a single file (usually a .pkg installer or zip)
+	// that is ready for notarization as-is
+	Notarize *Notarize `hcl:"notarize,block"`
+
 	// Sign are the settings for code-signing the binaries.
-	Sign Sign `hcl:"sign,block"`
+	Sign *Sign `hcl:"sign,block"`
 
 	// AppleId are the credentials to use to talk to Apple.
 	AppleId AppleId `hcl:"apple_id,block"`
@@ -41,6 +45,12 @@ type AppleId struct {
 	// specified if you're using an Apple ID account that has multiple
 	// teams.
 	Provider string `hcl:"provider,optional"`
+}
+
+// Options for notarizing a pre-built .pkg or .zip
+type Notarize struct {
+	Package string `hcl:"package"`
+	Staple  bool   `hcl:"staple"`
 }
 
 // Sign are the options for codesigning the binaries.

--- a/internal/config/testdata/notarize.hcl
+++ b/internal/config/testdata/notarize.hcl
@@ -1,0 +1,12 @@
+source = []
+bundle_id = "com.example.terraform"
+
+notarize {
+	package = "/path/to/terraform.pkg"
+	staple = true
+}
+
+apple_id {
+  username = "mitchellh@example.com"
+  password = "hello"
+}


### PR DESCRIPTION
To support a workflow where the item to be notarized (.pkg or .zip) does not require the existing `gon` process to perform the signing and packaging steps.

- Add new optional notarize section to the config
- Allow specifying notarize in lieu of sources