### PR TITLE
Fallback to environment if values not specified for AppleId

### DIFF
--- a/cmd/gon/main.go
+++ b/cmd/gon/main.go
@@ -140,6 +140,46 @@ func realMain() int {
 		}
 	}
 
+	// If not specified in the configuration, we initialize a new struct that we'll
+	// load with values from the environment.
+	if cfg.AppleId == nil {
+		cfg.AppleId = &config.AppleId{}
+	}
+
+	if cfg.AppleId.Username == "" {
+		appleIdUsername, ok := os.LookupEnv("AC_USERNAME")
+
+		if ok {
+			cfg.AppleId.Username = appleIdUsername
+		} else {
+			color.New(color.Bold, color.FgRed).Fprintf(os.Stdout, "❗️ No apple_id username provided\n")
+			color.New(color.FgRed).Fprintf(os.Stdout,
+				"An Apple ID username must be specified in the `apple_id` block or\n"+
+					"it must exist in the environment as AC_USERNAME,\n"+
+					"otherwise we won't be able to authenticate with Apple to notarize.\n")
+			return 1
+		}
+	}
+
+	if cfg.AppleId.Password == "" {
+		_, ok := os.LookupEnv("AC_PASSWORD")
+
+		if ok {
+			cfg.AppleId.Password = "@env:AC_PASSWORD"
+		} else {
+			color.New(color.Bold, color.FgRed).Fprintf(os.Stdout, "❗️ No apple_id password provided\n")
+			color.New(color.FgRed).Fprintf(os.Stdout,
+				"An Apple ID password (or lookup directive) must be specified in the\n"+
+					"`apple_id` block or it must exist in the environment as AC_PASSWORD,\n"+
+					"otherwise we won't be able to authenticate with Apple to notarize.\n")
+			return 1
+		}
+	}
+
+	if cfg.AppleId.Provider == "" {
+		cfg.AppleId.Provider = os.Getenv("AC_PROVIDER")
+	}
+
 	// If we're in source mode, then sign & package as configured
 	if len(cfg.Source) > 0 {
 		if cfg.Sign != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	Sign *Sign `hcl:"sign,block"`
 
 	// AppleId are the credentials to use to talk to Apple.
-	AppleId AppleId `hcl:"apple_id,block"`
+	AppleId *AppleId `hcl:"apple_id,block"`
 
 	// Zip, if present, creates a notarized zip file as the output. Note
 	// that zip files do not support stapling, so the final result will
@@ -32,14 +32,16 @@ type Config struct {
 
 // AppleId are the authentication settings for Apple systems.
 type AppleId struct {
-	// Username is your AC username, typically an email.
-	Username string `hcl:"username"`
+	// Username is your AC username, typically an email. This is required, but will
+	// be read from the environment via AC_USERNAME if not specified via config.
+	Username string `hcl:"username,optional"`
 
 	// Password is the password for your AC account. This also accepts
 	// two additional forms: '@keychain:<name>' which reads the password from
 	// the keychain and '@env:<name>' which reads the password from an
-	// an environmental variable named <name>.
-	Password string `hcl:"password"`
+	// an environmental variable named <name>. If omitted, it has the same effect
+	// as passing '@env:AC_PASSWORD'.
+	Password string `hcl:"password,optional"`
 
 	// Provider is the AC provider. This is optional and only needs to be
 	// specified if you're using an Apple ID account that has multiple

--- a/internal/config/testdata/entitle.hcl.golden
+++ b/internal/config/testdata/entitle.hcl.golden
@@ -6,7 +6,7 @@
  Notarize: ([]config.Notarize) <nil>,
  Sign: (*config.Sign)({
   ApplicationIdentity: (string) (len=3) "foo",
-  EntitlementsFile: (string) ""
+  EntitlementsFile: (string) (len=29) "/path/to/example.entitlements"
  }),
  AppleId: (*config.AppleId)({
   Username: (string) (len=21) "mitchellh@example.com",

--- a/internal/config/testdata/env_appleid.hcl
+++ b/internal/config/testdata/env_appleid.hcl
@@ -1,0 +1,6 @@
+source = ["./terraform"]
+bundle_id = "com.mitchellh.test.terraform"
+
+sign {
+  application_identity = "foo"
+}

--- a/internal/config/testdata/env_appleid.hcl.golden
+++ b/internal/config/testdata/env_appleid.hcl.golden
@@ -8,11 +8,7 @@
   ApplicationIdentity: (string) (len=3) "foo",
   EntitlementsFile: (string) ""
  }),
- AppleId: (*config.AppleId)({
-  Username: (string) (len=21) "mitchellh@example.com",
-  Password: (string) (len=5) "hello",
-  Provider: (string) ""
- }),
+ AppleId: (*config.AppleId)(<nil>),
  Zip: (*config.Zip)(<nil>),
  Dmg: (*config.Dmg)(<nil>)
 })

--- a/internal/config/testdata/notarize.hcl.golden
+++ b/internal/config/testdata/notarize.hcl.golden
@@ -10,11 +10,11 @@
   }
  },
  Sign: (*config.Sign)(<nil>),
- AppleId: (config.AppleId) {
+ AppleId: (*config.AppleId)({
   Username: (string) (len=21) "mitchellh@example.com",
   Password: (string) (len=5) "hello",
   Provider: (string) ""
- },
+ }),
  Zip: (*config.Zip)(<nil>),
  Dmg: (*config.Dmg)(<nil>)
 })

--- a/internal/config/testdata/notarize_multiple.hcl.golden
+++ b/internal/config/testdata/notarize_multiple.hcl.golden
@@ -15,11 +15,11 @@
   }
  },
  Sign: (*config.Sign)(<nil>),
- AppleId: (config.AppleId) {
+ AppleId: (*config.AppleId)({
   Username: (string) (len=21) "mitchellh@example.com",
   Password: (string) (len=5) "hello",
   Provider: (string) ""
- },
+ }),
  Zip: (*config.Zip)(<nil>),
  Dmg: (*config.Dmg)(<nil>)
 })


### PR DESCRIPTION
If any values are not specified in the config file for `AppleId`
we can fallback to pulling them from `AC_USERNAME`, `AC_PASSWORD`,
and `AC_PROVIDER`.

`AC_PASSWORD` will still be passed into `altool` using the `@env:`
prefix as supported by `altool` to avoid printing sensitive
information but all others will be read from the environment and
passed by value to `altool`.

Resolves #9 