### PR TITLE
notarize: use the provider when calling xcrun

### DIFF
--- a/notarize/upload.go
+++ b/notarize/upload.go
@@ -43,9 +43,18 @@ func upload(ctx context.Context, opts *Options) (string, error) {
 		"--primary-bundle-id", opts.BundleId,
 		"-u", opts.Username,
 		"-p", opts.Password,
+	}
+
+	if opts.Provider != "" {
+		cmd.Args = append(cmd.Args,
+			"--asc-provider", opts.Provider,
+		)
+	}
+
+	cmd.Args = append(cmd.Args,
 		"-f", opts.File,
 		"--output-format", "xml",
-	}
+	)
 
 	// We store all output in out for logging and in case there is an error
 	var out, combined bytes.Buffer


### PR DESCRIPTION
Even though the `provider` field was set, the call to `xcrun altool` didn't use it.

This PR fixes this by adding `--asc-provider`.