### PR TITLE
IgnorePathIssues config option to treat some issues as non-fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ gon helps you automate the process of notarization.
   - [Prerequisite: Acquiring a Developer ID Certificate](#prerequisite-acquiring-a-developer-id-certificate)
   - [Configuration File](#configuration-file)
   - [Notarization-Only Configuration](#notarization-only-configuration)
+  - [Handling Notarization Issues](#handling-notarization-issues)
   - [Processing Time](#processing-time)
   - [Using within Automation](#using-within-automation)
     - [Machine-Readable Output](#machine-readable-output)
@@ -309,6 +310,38 @@ apple_id {
 
 Note you may specify multiple `notarize` blocks to notarize multipel files
 concurrently.
+
+### Handling Notarization Issues
+
+After notarization, Apple sends a log containing what actions it performed. The
+log may contain a list of "issues", which may or may not be fatal. In some
+circumstances, a successful notarization can still produce a bundle that does
+not pass Gatekeeper and will fail to install. By default, `gon` will treat any
+issues reported by Apple as fatal due to the likelihood of an non-installable
+bundle.
+
+If you know that some issues reported by Apple that are non-fatal, such as an
+executable included in your bundle that is not essential for the install, you
+can treat these issues as non-fatal and `gon` will not fail. The
+`ignorable_path_issues` configuration option allows you to supply a regular
+expression that matches the `path` attached to the issues. The `path` reported
+by Apple normally has the format `<bundle> <file path>` so your regular
+expression should take this into account. Multiple paths should be composed
+into a single regular expression by broad matches or `|`. Supplying `".*"` will
+treat all issues as non-fatal (caveat emptor!).
+
+```hcl
+notarize {
+  path = "/path/to/terraform.pkg"
+...
+}
+
+apple_id {
+  ...
+}
+
+ignorable_path_issues = "^terraform.pkg Contents/Payload/usr/lib/inconsequential/boop$"
+```
 
 ### Processing Time
 

--- a/cmd/gon/item_test.go
+++ b/cmd/gon/item_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/gon/internal/config"
+	"github.com/mitchellh/gon/notarize"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleIssues_NoIssues(t *testing.T) {
+	// single issue
+	verifyHandleIssues(t, config.Config{})
+}
+
+func TestHandleIssues_DefaultIssues(t *testing.T) {
+	// single issue
+	verifyHandleIssues(t, config.Config{}, logAndExpectedError{
+		issue: notarize.LogIssue{
+			Severity: "borked",
+			Path:     "pkg foo/bar/baz",
+			Message:  "nope nope nope",
+		},
+		expectedError: "borked for path \"pkg foo/bar/baz\": nope nope nope",
+	})
+
+	// two issues
+	verifyHandleIssues(t,
+		config.Config{},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "borked",
+				Path:     "pkg foo/bar/baz",
+				Message:  "nope nope nope",
+			},
+			expectedError: "borked for path \"pkg foo/bar/baz\": nope nope nope",
+		},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "verysevere",
+				Path:     "pkg foo/bar/bang",
+				Message:  "no, just no",
+			},
+			expectedError: "verysevere for path \"pkg foo/bar/bang\": no, just no",
+		},
+	)
+}
+
+func TestHandleIssues_IgnoreAllIssues(t *testing.T) {
+	regex := "^pkg foo/bar/.*$"
+
+	// single issue
+	verifyHandleIssues(t,
+		config.Config{IgnorePathIssues: &regex},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "borked",
+				Path:     "pkg foo/bar/baz",
+				Message:  "nope nope nope",
+			},
+		},
+	)
+
+	// two issues
+	verifyHandleIssues(t,
+		config.Config{IgnorePathIssues: &regex},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "borked",
+				Path:     "pkg foo/bar/baz",
+				Message:  "nope nope nope",
+			},
+		},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "verysevere",
+				Path:     "pkg foo/bar/bang",
+				Message:  "no, just no",
+			},
+		},
+	)
+}
+
+func TestHandleIssues_IgnoreSomeIssues(t *testing.T) {
+	regex := "^pkg foo/bar/baz$"
+
+	// single issue
+	verifyHandleIssues(t,
+		config.Config{IgnorePathIssues: &regex},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "borked",
+				Path:     "pkg foo/bar/baz",
+				Message:  "nope nope nope",
+			},
+		},
+	)
+
+	// two issues
+	verifyHandleIssues(t,
+		config.Config{IgnorePathIssues: &regex},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "borked",
+				Path:     "pkg foo/bar/baz",
+				Message:  "nope nope nope",
+			},
+		},
+		logAndExpectedError{
+			issue: notarize.LogIssue{
+				Severity: "verysevere",
+				Path:     "pkg foo/bar/bang",
+				Message:  "no, just no",
+			},
+			expectedError: "verysevere for path \"pkg foo/bar/bang\": no, just no",
+		},
+	)
+}
+
+type logAndExpectedError struct {
+	issue         notarize.LogIssue
+	expectedError string
+}
+
+func expectedErrors(logAndExpectedErrors []logAndExpectedError) int {
+	var ee = 0
+	for _, lee := range logAndExpectedErrors {
+		if lee.expectedError != "" {
+			ee++
+		}
+	}
+	return ee
+}
+
+func verifyHandleIssues(t *testing.T, cfg config.Config, logAndExpectedErrors ...logAndExpectedError) {
+	logger := hclog.L()
+
+	issues := make([]notarize.LogIssue, len(logAndExpectedErrors))
+	for idx, lee := range logAndExpectedErrors {
+		issues[idx] = lee.issue
+	}
+
+	var lock sync.Mutex
+	log := notarize.Log{Issues: issues}
+
+	opts := processOptions{
+		Config:     &cfg,
+		Logger:     logger,
+		Prefix:     "TestHandleIssues",
+		OutputLock: &lock,
+	}
+
+	err := handleIssues(&opts, &log)
+
+	if expectedErrors(logAndExpectedErrors) == 0 {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err)
+
+		me, ok := err.(*multierror.Error)
+		require.True(t, ok)
+		require.Len(t, me.WrappedErrors(), expectedErrors(logAndExpectedErrors))
+		idx := 0
+		for _, lee := range logAndExpectedErrors {
+			if lee.expectedError != "" {
+				require.EqualError(t, me.WrappedErrors()[idx], lee.expectedError)
+				idx++
+			}
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,13 @@ type Config struct {
 	// Dmg, if present, creates a dmg file to package the signed `Source` files
 	// into. Dmg files support stapling so this allows offline usage.
 	Dmg *Dmg `hcl:"dmg,block"`
+
+	// IgnorePathIssues, if present, will allow a notarization to succeed in the
+	// presence of issues reported by Apple. Supply a regular expression to match
+	// against the path(s) for which issues should be considered non-fatal, or
+	// ".*" to match all issues.
+	// Note that paths reported by Apple take the format: "<bundle> <file>".
+	IgnorePathIssues *string `hcl:"ignorable_path_issues,optional"`
 }
 
 // AppleId are the authentication settings for Apple systems.

--- a/internal/config/testdata/basic.hcl.golden
+++ b/internal/config/testdata/basic.hcl.golden
@@ -14,5 +14,6 @@
   Provider: (string) ""
  }),
  Zip: (*config.Zip)(<nil>),
- Dmg: (*config.Dmg)(<nil>)
+ Dmg: (*config.Dmg)(<nil>),
+ IgnorePathIssues: (*string)(<nil>)
 })

--- a/internal/config/testdata/entitle.hcl.golden
+++ b/internal/config/testdata/entitle.hcl.golden
@@ -14,5 +14,6 @@
   Provider: (string) ""
  }),
  Zip: (*config.Zip)(<nil>),
- Dmg: (*config.Dmg)(<nil>)
+ Dmg: (*config.Dmg)(<nil>),
+ IgnorePathIssues: (*string)(<nil>)
 })

--- a/internal/config/testdata/env_appleid.hcl.golden
+++ b/internal/config/testdata/env_appleid.hcl.golden
@@ -10,5 +10,6 @@
  }),
  AppleId: (*config.AppleId)(<nil>),
  Zip: (*config.Zip)(<nil>),
- Dmg: (*config.Dmg)(<nil>)
+ Dmg: (*config.Dmg)(<nil>),
+ IgnorePathIssues: (*string)(<nil>)
 })

--- a/internal/config/testdata/notarize.hcl.golden
+++ b/internal/config/testdata/notarize.hcl.golden
@@ -16,5 +16,6 @@
   Provider: (string) ""
  }),
  Zip: (*config.Zip)(<nil>),
- Dmg: (*config.Dmg)(<nil>)
+ Dmg: (*config.Dmg)(<nil>),
+ IgnorePathIssues: (*string)(<nil>)
 })

--- a/internal/config/testdata/notarize_multiple.hcl.golden
+++ b/internal/config/testdata/notarize_multiple.hcl.golden
@@ -21,5 +21,6 @@
   Provider: (string) ""
  }),
  Zip: (*config.Zip)(<nil>),
- Dmg: (*config.Dmg)(<nil>)
+ Dmg: (*config.Dmg)(<nil>),
+ IgnorePathIssues: (*string)(<nil>)
 })


### PR DESCRIPTION
I'm getting notarization working for our Node.js .pkg files (ref https://github.com/nodejs/node/issues/29216) using `gon` but we have a small problem: there are binaries deep inside the pkg (inside a pkg for npm which is inside the pkg) that is neither signed or hardened. It's a minor dependency of npm that's not essential to installing Node and it'll only be encountered on command-line usage so ought to not be a problem for users.

Apple passes the notarization but reports 3 "issues" for this particular file, because of #6, any issues are treated as fatal. But in this case, it doesn't appear to cause any problems for the package, it can be installed and used just fine even with this unsigned executable inside it.

So, this PR is a suggestion of a way around that. It lets you keep the #6 behaviour and lets users of `gon` opt-in to treating certain issues as non-fatal by matching the `"path"` reported by Apple for each issue. Happy to adjust as needed to fit nicely with the rest of the tool nicely, or perhaps you have a suggestion for an alternative route?

Here's a copy of a log with these issues so you can see what we're dealing with: https://gist.github.com/rvagg/d9befda67accfe1355f7cf6da399980b, it results in this stderr:

```
    3 issues during notarization:
    Issue #1 (warning) for path "node-v14.0.0-nightly202001223e5fd51bb9.pkg/npm-v6.13.6.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-pick 9e4977fe22 src: better encapsulate native immediate list
size/vendor/macos/term-size": The binary is not signed.
    Issue #2 (warning) for path "node-v14.0.0-nightly202001223e5fd51bb9.pkg/npm-v6.13.6.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-size/vendor/macos/term-size": The signature does not include a secure timestamp.
    Issue #3 (warning) for path "node-v14.0.0-nightly202001223e5fd51bb9.pkg/npm-v6.13.6.pkg Contents/Payload/usr/local/lib/node_modules/npm/node_modules/term-size/vendor/macos/term-size": The executable does not have the hardened runtime enabled.
```
