### PR TITLE
Add note about the Apple Developer Program fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Before using `gon`, you must acquire a Developer ID Certificate. To do
 this, you can either do it via the web or via Xcode locally on a Mac. Using
 Xcode is easier if you already have it installed.
 
+Also, before you can get a Developer ID Certificate, Apple requires you to [enroll in the Apple Developer Program](https://developer.apple.com/programs/enroll/). The membership fee is $99/year.
+
 Via the web:
 
   1. Sign into [developer.apple.com](https://developer.apple.com) with valid


### PR DESCRIPTION
I was trying out the steps listed to get a Developer ID certificate, and I realized I needed to:

1. enroll in the Apple Developer Program
1. pay $99 for the enrollment

(Without completing these steps, the "certificates" link in the README.md doesn't work.)

I thought it'd be good to give users a heads up about these required steps in case they don't already know this, particular for folks coming from the Go development world more so than the Apple development world.