### PR TITLE
Implements #30, a way to pass --deep flag to codesign tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ apple_id {
 
 sign {
   application_identity = "Developer ID Application: Mitchell Hashimoto"
+  deep = false
 }
 
 dmg {
@@ -174,7 +175,8 @@ zip {
         "password":  "@env:AC_PASSWORD"
     },
     "sign" :{
-        "application_identity" : "Developer ID Application: Mitchell Hashimoto"
+        "application_identity" : "Developer ID Application: Mitchell Hashimoto",
+        "deep": false
     },
     "dmg" :{
         "output_path":  "terraform.dmg",
@@ -223,6 +225,10 @@ Supported configurations:
       certificate to use to sign applications. This accepts any valid value for the `-s`
       flag for the `codesign` binary on macOS. See `man codesign` for detailed
       documentation on accepted values.
+
+    * `deep` (`bool` _optional_) - If true, the `--deep` flag is used, which will recursively
+    codesign any directory paths (such as an *.app directory, for example.) Has no effect on
+    individual file paths.
 
     * `entitlements_file` (`string` _optional_) - The full path to a plist format .entitlements file, used for the `--entitlements` argument to `codesign`
 

--- a/cmd/gon/main.go
+++ b/cmd/gon/main.go
@@ -184,6 +184,7 @@ func realMain() int {
 				Files:        cfg.Source,
 				Identity:     cfg.Sign.ApplicationIdentity,
 				Entitlements: cfg.Sign.EntitlementsFile,
+				Deep:         cfg.Sign.Deep,
 				Logger:       logger.Named("sign"),
 			})
 			if err != nil {
@@ -232,6 +233,7 @@ func realMain() int {
 			err = sign.Sign(context.Background(), &sign.Options{
 				Files:    []string{cfg.Dmg.OutputPath},
 				Identity: cfg.Sign.ApplicationIdentity,
+				Deep:     cfg.Sign.Deep,
 				Logger:   logger.Named("dmg"),
 			})
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,8 @@ type Sign struct {
 	ApplicationIdentity string `hcl:"application_identity"`
 	// Specify a path to an entitlements file in plist format
 	EntitlementsFile string `hcl:"entitlements_file,optional"`
+	// Specific to request a --deep codesigning.
+	Deep bool `hcl:"deep,optional"`
 }
 
 // Dmg are the options for a dmg file as output.

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -27,6 +27,10 @@ type Options struct {
 	// Entitlements is an (optional) path to a plist format .entitlements file
 	Entitlements string
 
+	// Deep is an (optional) toggle to force the --deep flag when codesigning.
+	// This can be useful for signing *.app directories and their child files.
+	Deep bool
+
 	// Output is an io.Writer where the output of the command will be written.
 	// If this is nil then the output will only be sent to the log (if set)
 	// or in the error result value if signing failed.
@@ -74,6 +78,10 @@ func Sign(ctx context.Context, opts *Options) error {
 
 	if len(opts.Entitlements) > 0 {
 		cmd.Args = append(cmd.Args, "--entitlements", opts.Entitlements)
+	}
+
+	if opts.Deep {
+		cmd.Args = append(cmd.Args, "--deep")
 	}
 
 	// Append the files that we want to sign


### PR DESCRIPTION
Hello! 👋 I needed this so I implemented it. 🎩
(Kudos for a solid project layout; the code was easy to follow.)

I think this could help people doing OSX *.app's since those are secretly directories and it's impossible to notorize them without codesigning every file within.

Let me know what you think or if I missed anything. ("Allow edits by maintainers" is enabled so feel free to tweak anything.)

Thanks for making this tool. OSX security is a clusterfuck to wrap your mind around at first and it helps a ton.
