### PR TITLE
Add support for codesign requirements:

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ Supported configurations:
 
     * `entitlements_file` (`string` _optional_) - The full path to a plist format .entitlements file, used for the `--entitlements` argument to `codesign`
 
+    * `requirements` (`string` _optional_) - The full requirements string, used for the `-r=` argument to `codesign`.
+
+      See [Code Designated Requirement](https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG6).
+      The requirements are wrapped with `"` before being passed, `designated => anchor trusted` will be passed to codesign as `-r="designated => anchor trusted"`.
+
   * `dmg` (_optional_) - Settings related to creating a disk image (dmg) as output.
     This will only be created if this is specified. The dmg will also have the
     notarization ticket stapled so that it can be verified offline and

--- a/cmd/gon/main.go
+++ b/cmd/gon/main.go
@@ -185,6 +185,7 @@ func realMain() int {
 				Identity:     cfg.Sign.ApplicationIdentity,
 				Entitlements: cfg.Sign.EntitlementsFile,
 				Logger:       logger.Named("sign"),
+				Requirements: cfg.Sign.Requirements,
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stdout, color.RedString("❗️ Error signing files:\n\n%s\n", err))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,9 @@ type Sign struct {
 	ApplicationIdentity string `hcl:"application_identity"`
 	// Specify a path to an entitlements file in plist format
 	EntitlementsFile string `hcl:"entitlements_file,optional"`
+	// Requirements is used to pass requirements to the codesign binary.
+	// See https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG6
+	Requirements string `hcl:"requirements,optional"`
 }
 
 // Dmg are the options for a dmg file as output.

--- a/internal/config/testdata/entitle.hcl.golden
+++ b/internal/config/testdata/entitle.hcl.golden
@@ -6,7 +6,8 @@
  Notarize: ([]config.Notarize) <nil>,
  Sign: (*config.Sign)({
   ApplicationIdentity: (string) (len=3) "foo",
-  EntitlementsFile: (string) (len=29) "/path/to/example.entitlements"
+  EntitlementsFile: (string) (len=29) "/path/to/example.entitlements",
+  Requirements: (string) ""
  }),
  AppleId: (*config.AppleId)({
   Username: (string) (len=21) "mitchellh@example.com",

--- a/internal/config/testdata/env_appleid.hcl.golden
+++ b/internal/config/testdata/env_appleid.hcl.golden
@@ -6,7 +6,8 @@
  Notarize: ([]config.Notarize) <nil>,
  Sign: (*config.Sign)({
   ApplicationIdentity: (string) (len=3) "foo",
-  EntitlementsFile: (string) ""
+  EntitlementsFile: (string) "",
+  Requirements: (string) ""
  }),
  AppleId: (*config.AppleId)(<nil>),
  Zip: (*config.Zip)(<nil>),

--- a/internal/config/testdata/requirements.hcl
+++ b/internal/config/testdata/requirements.hcl
@@ -1,0 +1,12 @@
+source = ["./terraform"]
+bundle_id = "com.mitchellh.test.terraform"
+
+apple_id {
+  username = "mitchellh@example.com"
+  password = "hello"
+}
+
+sign {
+  application_identity = "foo"
+  requirements = "designated => anchor trusted and identifier com.mitchellh"
+}

--- a/internal/config/testdata/requirements.hcl.golden
+++ b/internal/config/testdata/requirements.hcl.golden
@@ -7,7 +7,7 @@
  Sign: (*config.Sign)({
   ApplicationIdentity: (string) (len=3) "foo",
   EntitlementsFile: (string) "",
-  Requirements: (string) ""
+  Requirements: (string) (len=57) "designated => anchor trusted and identifier com.mitchellh"
  }),
  AppleId: (*config.AppleId)({
   Username: (string) (len=21) "mitchellh@example.com",

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -38,6 +38,10 @@ type Options struct {
 	// BaseCmd is the base command for executing the codesign binary. This is
 	// used for tests to overwrite where the codesign binary is.
 	BaseCmd *exec.Cmd
+
+	// Requirements is used to pass requirements to the codesign binary.
+	// See https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG6
+	Requirements string
 }
 
 // Sign signs one or more files returning an error if any.
@@ -74,6 +78,12 @@ func Sign(ctx context.Context, opts *Options) error {
 
 	if len(opts.Entitlements) > 0 {
 		cmd.Args = append(cmd.Args, "--entitlements", opts.Entitlements)
+	}
+
+	if len(opts.Requirements) > 0 {
+		//requirementsString := fmt.Sprintf("-r=\"%s\"", opts.Requirements)
+		requirementsString := fmt.Sprintf("-r=%s", opts.Requirements)
+		cmd.Args = append(cmd.Args, requirementsString)
 	}
 
 	// Append the files that we want to sign


### PR DESCRIPTION
https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG6

This allows adding a requirements line to the configuration to specify the requirements.
The line should look something like:

designated => anchor trusted and identifier com.foo.bar