### PR TITLE
fix create-dmg: --openfolder not supported on Apple Silicon

### DIFF
--- a/vendor/create-dmg/create-dmg
+++ b/vendor/create-dmg/create-dmg
@@ -367,8 +367,10 @@ echo "Done fixing permissions."
 # make the top window open itself on mount:
 if [ $SANDBOX_SAFE -eq 0 ]; then
 	echo "Blessing started"
-	bless --folder "${MOUNT_DIR}" --openfolder "${MOUNT_DIR}"
+	bless --folder "${MOUNT_DIR}"
 	echo "Blessing finished"
+	echo "Opening directory"
+	open "${MOUNT_DIR}"
 else
 	echo "Skipping blessing on sandbox"
 fi


### PR DESCRIPTION
When running the **create-dmg** script on an Apple Silicon Mac it stopped on line 370 with an error:

`bless: The 'openfolder' is not supported on Apple Silicon devices.`

This patch fixes the issue by using a separate **open** command after blessing.